### PR TITLE
Implement managed resource operations for TF5 and TF6

### DIFF
--- a/tofuprovider/internal/tf5/managed_resource.go
+++ b/tofuprovider/internal/tf5/managed_resource.go
@@ -3,20 +3,67 @@ package tf5
 import (
 	"context"
 	"fmt"
+	"iter"
+	"slices"
 
 	"github.com/opentofu/provider-client/tofuprovider/grpc/tfplugin5"
 	"github.com/opentofu/provider-client/tofuprovider/internal/common"
 	"github.com/opentofu/provider-client/tofuprovider/providerops"
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
 )
 
 // ApplyManagedResourceChange implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) ApplyManagedResourceChange(ctx context.Context, req *providerops.ApplyManagedResourceChangeRequest) (providerops.ApplyManagedResourceChangeResponse, error) {
-	panic("unimplemented")
+	priorState, err := makeDynamicValueMsgpack(req.PriorState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PriorState value: %w", err)
+	}
+	plannedNewState, err := makeDynamicValueMsgpack(req.PlannedNewState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PlannedNewState value: %w", err)
+	}
+	config, err := makeDynamicValueMsgpack(req.Config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Config value: %w", err)
+	}
+
+	var providerMeta *tfplugin5.DynamicValue
+	if req.ProviderMeta != providerschema.NoDynamicValue {
+		providerMeta, err = makeDynamicValueMsgpack(req.ProviderMeta)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ProviderMeta value: %w", err)
+		}
+	}
+
+	protoReq := &tfplugin5.ApplyResourceChange_Request{
+		TypeName:       req.ResourceType,
+		PriorState:     priorState,
+		PlannedState:   plannedNewState,
+		Config:         config,
+		PlannedPrivate: req.PlannedProviderInternal,
+		ProviderMeta:   providerMeta,
+	}
+
+	protoResp, err := p.client.ApplyResourceChange(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return applyManagedResourceChangeResponse{proto: protoResp}, nil
 }
 
 // ImportManagedResourceState implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) ImportManagedResourceState(ctx context.Context, req *providerops.ImportManagedResourceStateRequest) (providerops.ImportManagedResourceStateResponse, error) {
-	panic("unimplemented")
+	protoReq := &tfplugin5.ImportResourceState_Request{
+		TypeName:           req.ResourceType,
+		Id:                 req.ID,
+		ClientCapabilities: prepareClientCapabilities(req.ClientCapabilities),
+	}
+
+	protoResp, err := p.client.ImportResourceState(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return importManagedResourceStateResponse{proto: protoResp}, nil
 }
 
 // MoveManagedResourceState implements tofuprovider.GRPCPluginProvider.
@@ -26,12 +73,72 @@ func (p *Provider) MoveManagedResourceState(ctx context.Context, req *providerop
 
 // PlanManagedResourceChange implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) PlanManagedResourceChange(ctx context.Context, req *providerops.PlanManagedResourceChangeRequest) (providerops.PlanManagedResourceChangeResponse, error) {
-	panic("unimplemented")
+	priorState, err := makeDynamicValueMsgpack(req.PriorState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PriorState value: %w", err)
+	}
+	proposedNewState, err := makeDynamicValueMsgpack(req.ProposedNewState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ProposedNewState value: %w", err)
+	}
+	config, err := makeDynamicValueMsgpack(req.Config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Config value: %w", err)
+	}
+
+	var providerMeta *tfplugin5.DynamicValue
+	if req.ProviderMeta != providerschema.NoDynamicValue {
+		providerMeta, err = makeDynamicValueMsgpack(req.ProviderMeta)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ProviderMeta value: %w", err)
+		}
+	}
+
+	protoReq := &tfplugin5.PlanResourceChange_Request{
+		TypeName:           req.ResourceType,
+		PriorState:         priorState,
+		ProposedNewState:   proposedNewState,
+		Config:             config,
+		PriorPrivate:       req.PriorProviderInternal,
+		ProviderMeta:       providerMeta,
+		ClientCapabilities: prepareClientCapabilities(req.ClientCapabilities),
+	}
+
+	protoResp, err := p.client.PlanResourceChange(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return planManagedResourceChangeResponse{proto: protoResp}, nil
 }
 
 // ReadManagedResource implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) ReadManagedResource(ctx context.Context, req *providerops.ReadManagedResourceRequest) (providerops.ReadManagedResourceResponse, error) {
-	panic("unimplemented")
+	currentState, err := makeDynamicValueMsgpack(req.CurrentState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CurrentState value: %w", err)
+	}
+
+	var providerMeta *tfplugin5.DynamicValue
+	if req.ProviderMeta != providerschema.NoDynamicValue {
+		providerMeta, err = makeDynamicValueMsgpack(req.ProviderMeta)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ProviderMeta value: %w", err)
+		}
+	}
+
+	protoReq := &tfplugin5.ReadResource_Request{
+		TypeName:           req.ResourceType,
+		CurrentState:       currentState,
+		Private:            req.ProviderInternal,
+		ProviderMeta:       providerMeta,
+		ClientCapabilities: prepareClientCapabilities(req.ClientCapabilities),
+	}
+
+	protoResp, err := p.client.ReadResource(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return readManagedResourceResponse{proto: protoResp}, nil
 }
 
 // UpgradeManagedResourceState implements tofuprovider.GRPCPluginProvider.
@@ -65,4 +172,136 @@ type validateManagedResourceConfigResponse struct {
 // Diagnostics implements providerops.ValidateEphemeralResourceConfigResponse.
 func (v validateManagedResourceConfigResponse) Diagnostics() providerops.Diagnostics {
 	return diagnostics{proto: v.proto.Diagnostics}
+}
+
+type planManagedResourceChangeResponse struct {
+	proto *tfplugin5.PlanResourceChange_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: p.proto.Diagnostics}
+}
+
+// PlannedNewState implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) PlannedNewState() providerschema.DynamicValueOut {
+	return dynamicValue{proto: p.proto.PlannedState}
+}
+
+// PlannedProviderInternal implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) PlannedProviderInternal() []byte {
+	return p.proto.PlannedPrivate
+}
+
+// LegacyTypeSystem implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) LegacyTypeSystem() bool {
+	return p.proto.LegacyTypeSystem
+}
+
+// Deferred implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) Deferred() providerops.Deferred {
+	if p.proto.Deferred == nil {
+		return nil
+	}
+	return deferred{proto: p.proto.Deferred}
+}
+
+type applyManagedResourceChangeResponse struct {
+	proto *tfplugin5.ApplyResourceChange_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: a.proto.Diagnostics}
+}
+
+// PlannedNewState implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) PlannedNewState() providerschema.DynamicValueOut {
+	if a.proto.NewState == nil {
+		return nil
+	}
+	return dynamicValue{proto: a.proto.NewState}
+}
+
+// ProviderInternal implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) ProviderInternal() []byte {
+	return a.proto.Private
+}
+
+// LegacyTypeSystem implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) LegacyTypeSystem() bool {
+	return a.proto.LegacyTypeSystem
+}
+
+type readManagedResourceResponse struct {
+	proto *tfplugin5.ReadResource_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: r.proto.Diagnostics}
+}
+
+// NewState implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) NewState() providerschema.DynamicValueOut {
+	if r.proto.NewState == nil {
+		return nil
+	}
+	return dynamicValue{proto: r.proto.NewState}
+}
+
+// ProviderInternal implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) ProviderInternal() []byte {
+	return r.proto.Private
+}
+
+// Deferred implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) Deferred() providerops.Deferred {
+	if r.proto.Deferred == nil {
+		return nil
+	}
+	return deferred{proto: r.proto.Deferred}
+}
+
+type importManagedResourceStateResponse struct {
+	proto *tfplugin5.ImportResourceState_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.ImportManagedResourceStateResponse.
+func (i importManagedResourceStateResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: i.proto.Diagnostics}
+}
+
+// ImportedResources implements providerops.ImportManagedResourceStateResponse.
+func (i importManagedResourceStateResponse) ImportedResources() iter.Seq[providerops.ImportedManagedResource] {
+	return common.MapSeq(slices.Values(i.proto.ImportedResources), func(protoRes *tfplugin5.ImportResourceState_ImportedResource) providerops.ImportedManagedResource {
+		return importedManagedResource{proto: protoRes}
+	})
+}
+
+type importedManagedResource struct {
+	proto *tfplugin5.ImportResourceState_ImportedResource
+	common.SealedImpl
+}
+
+// ResourceType implements providerops.ImportedManagedResource.
+func (i importedManagedResource) ResourceType() string {
+	return i.proto.TypeName
+}
+
+// State implements providerops.ImportedManagedResource.
+func (i importedManagedResource) State() providerschema.DynamicValueOut {
+	if i.proto.State == nil {
+		return nil
+	}
+	return dynamicValue{proto: i.proto.State}
+}
+
+// ProviderInternal implements providerops.ImportedManagedResource.
+func (i importedManagedResource) ProviderInternal() []byte {
+	return i.proto.Private
 }

--- a/tofuprovider/internal/tf5/provider_schema.go
+++ b/tofuprovider/internal/tf5/provider_schema.go
@@ -117,6 +117,14 @@ func (s schema) SchemaVersion() int64 {
 	return s.proto.Version
 }
 
+// DocDescription implements providerschema.Schema.
+func (s schema) DocDescription() (string, providerschema.DocStringFormat) {
+	if s.proto.Block == nil {
+		return "", providerschema.DocStringPlain
+	}
+	return s.proto.Block.Description, docStringFormat(s.proto.Block.DescriptionKind)
+}
+
 type attribute struct {
 	proto *tfplugin5.Schema_Attribute
 	common.SealedImpl

--- a/tofuprovider/internal/tf6/managed_resource.go
+++ b/tofuprovider/internal/tf6/managed_resource.go
@@ -3,20 +3,67 @@ package tf6
 import (
 	"context"
 	"fmt"
+	"iter"
+	"slices"
 
 	"github.com/opentofu/provider-client/tofuprovider/grpc/tfplugin6"
 	"github.com/opentofu/provider-client/tofuprovider/internal/common"
 	"github.com/opentofu/provider-client/tofuprovider/providerops"
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
 )
 
 // ApplyManagedResourceChange implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) ApplyManagedResourceChange(ctx context.Context, req *providerops.ApplyManagedResourceChangeRequest) (providerops.ApplyManagedResourceChangeResponse, error) {
-	panic("unimplemented")
+	priorState, err := makeDynamicValueMsgpack(req.PriorState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PriorState value: %w", err)
+	}
+	plannedNewState, err := makeDynamicValueMsgpack(req.PlannedNewState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PlannedNewState value: %w", err)
+	}
+	config, err := makeDynamicValueMsgpack(req.Config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Config value: %w", err)
+	}
+
+	var providerMeta *tfplugin6.DynamicValue
+	if req.ProviderMeta != providerschema.NoDynamicValue {
+		providerMeta, err = makeDynamicValueMsgpack(req.ProviderMeta)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ProviderMeta value: %w", err)
+		}
+	}
+
+	protoReq := &tfplugin6.ApplyResourceChange_Request{
+		TypeName:       req.ResourceType,
+		PriorState:     priorState,
+		PlannedState:   plannedNewState,
+		Config:         config,
+		PlannedPrivate: req.PlannedProviderInternal,
+		ProviderMeta:   providerMeta,
+	}
+
+	protoResp, err := p.client.ApplyResourceChange(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return applyManagedResourceChangeResponse{proto: protoResp}, nil
 }
 
 // ImportManagedResourceState implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) ImportManagedResourceState(ctx context.Context, req *providerops.ImportManagedResourceStateRequest) (providerops.ImportManagedResourceStateResponse, error) {
-	panic("unimplemented")
+	protoReq := &tfplugin6.ImportResourceState_Request{
+		TypeName:           req.ResourceType,
+		Id:                 req.ID,
+		ClientCapabilities: prepareClientCapabilities(req.ClientCapabilities),
+	}
+
+	protoResp, err := p.client.ImportResourceState(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return importManagedResourceStateResponse{proto: protoResp}, nil
 }
 
 // MoveManagedResourceState implements tofuprovider.GRPCPluginProvider.
@@ -26,12 +73,72 @@ func (p *Provider) MoveManagedResourceState(ctx context.Context, req *providerop
 
 // PlanManagedResourceChange implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) PlanManagedResourceChange(ctx context.Context, req *providerops.PlanManagedResourceChangeRequest) (providerops.PlanManagedResourceChangeResponse, error) {
-	panic("unimplemented")
+	priorState, err := makeDynamicValueMsgpack(req.PriorState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PriorState value: %w", err)
+	}
+	proposedNewState, err := makeDynamicValueMsgpack(req.ProposedNewState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ProposedNewState value: %w", err)
+	}
+	config, err := makeDynamicValueMsgpack(req.Config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Config value: %w", err)
+	}
+
+	var providerMeta *tfplugin6.DynamicValue
+	if req.ProviderMeta != providerschema.NoDynamicValue {
+		providerMeta, err = makeDynamicValueMsgpack(req.ProviderMeta)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ProviderMeta value: %w", err)
+		}
+	}
+
+	protoReq := &tfplugin6.PlanResourceChange_Request{
+		TypeName:           req.ResourceType,
+		PriorState:         priorState,
+		ProposedNewState:   proposedNewState,
+		Config:             config,
+		PriorPrivate:       req.PriorProviderInternal,
+		ProviderMeta:       providerMeta,
+		ClientCapabilities: prepareClientCapabilities(req.ClientCapabilities),
+	}
+
+	protoResp, err := p.client.PlanResourceChange(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return planManagedResourceChangeResponse{proto: protoResp}, nil
 }
 
-// ReadManagedResourceChange implements tofuprovider.GRPCPluginProvider.
+// ReadManagedResource implements tofuprovider.GRPCPluginProvider.
 func (p *Provider) ReadManagedResource(ctx context.Context, req *providerops.ReadManagedResourceRequest) (providerops.ReadManagedResourceResponse, error) {
-	panic("unimplemented")
+	currentState, err := makeDynamicValueMsgpack(req.CurrentState)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CurrentState value: %w", err)
+	}
+
+	var providerMeta *tfplugin6.DynamicValue
+	if req.ProviderMeta != providerschema.NoDynamicValue {
+		providerMeta, err = makeDynamicValueMsgpack(req.ProviderMeta)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ProviderMeta value: %w", err)
+		}
+	}
+
+	protoReq := &tfplugin6.ReadResource_Request{
+		TypeName:           req.ResourceType,
+		CurrentState:       currentState,
+		Private:            req.ProviderInternal,
+		ProviderMeta:       providerMeta,
+		ClientCapabilities: prepareClientCapabilities(req.ClientCapabilities),
+	}
+
+	protoResp, err := p.client.ReadResource(ctx, protoReq)
+	if err != nil {
+		return nil, err
+	}
+	return readManagedResourceResponse{proto: protoResp}, nil
 }
 
 // UpgradeManagedResourceState implements tofuprovider.GRPCPluginProvider.
@@ -65,4 +172,136 @@ type validateManagedResourceConfigResponse struct {
 // Diagnostics implements providerops.ValidateEphemeralResourceConfigResponse.
 func (v validateManagedResourceConfigResponse) Diagnostics() providerops.Diagnostics {
 	return diagnostics{proto: v.proto.Diagnostics}
+}
+
+type planManagedResourceChangeResponse struct {
+	proto *tfplugin6.PlanResourceChange_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: p.proto.Diagnostics}
+}
+
+// PlannedNewState implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) PlannedNewState() providerschema.DynamicValueOut {
+	return dynamicValue{proto: p.proto.PlannedState}
+}
+
+// PlannedProviderInternal implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) PlannedProviderInternal() []byte {
+	return p.proto.PlannedPrivate
+}
+
+// LegacyTypeSystem implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) LegacyTypeSystem() bool {
+	return p.proto.LegacyTypeSystem
+}
+
+// Deferred implements providerops.PlanManagedResourceChangeResponse.
+func (p planManagedResourceChangeResponse) Deferred() providerops.Deferred {
+	if p.proto.Deferred == nil {
+		return nil
+	}
+	return deferred{proto: p.proto.Deferred}
+}
+
+type applyManagedResourceChangeResponse struct {
+	proto *tfplugin6.ApplyResourceChange_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: a.proto.Diagnostics}
+}
+
+// PlannedNewState implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) PlannedNewState() providerschema.DynamicValueOut {
+	if a.proto.NewState == nil {
+		return nil
+	}
+	return dynamicValue{proto: a.proto.NewState}
+}
+
+// ProviderInternal implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) ProviderInternal() []byte {
+	return a.proto.Private
+}
+
+// LegacyTypeSystem implements providerops.ApplyManagedResourceChangeResponse.
+func (a applyManagedResourceChangeResponse) LegacyTypeSystem() bool {
+	return a.proto.LegacyTypeSystem
+}
+
+type readManagedResourceResponse struct {
+	proto *tfplugin6.ReadResource_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: r.proto.Diagnostics}
+}
+
+// NewState implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) NewState() providerschema.DynamicValueOut {
+	if r.proto.NewState == nil {
+		return nil
+	}
+	return dynamicValue{proto: r.proto.NewState}
+}
+
+// ProviderInternal implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) ProviderInternal() []byte {
+	return r.proto.Private
+}
+
+// Deferred implements providerops.ReadManagedResourceResponse.
+func (r readManagedResourceResponse) Deferred() providerops.Deferred {
+	if r.proto.Deferred == nil {
+		return nil
+	}
+	return deferred{proto: r.proto.Deferred}
+}
+
+type importManagedResourceStateResponse struct {
+	proto *tfplugin6.ImportResourceState_Response
+	common.SealedImpl
+}
+
+// Diagnostics implements providerops.ImportManagedResourceStateResponse.
+func (i importManagedResourceStateResponse) Diagnostics() providerops.Diagnostics {
+	return diagnostics{proto: i.proto.Diagnostics}
+}
+
+// ImportedResources implements providerops.ImportManagedResourceStateResponse.
+func (i importManagedResourceStateResponse) ImportedResources() iter.Seq[providerops.ImportedManagedResource] {
+	return common.MapSeq(slices.Values(i.proto.ImportedResources), func(protoRes *tfplugin6.ImportResourceState_ImportedResource) providerops.ImportedManagedResource {
+		return importedManagedResource{proto: protoRes}
+	})
+}
+
+type importedManagedResource struct {
+	proto *tfplugin6.ImportResourceState_ImportedResource
+	common.SealedImpl
+}
+
+// ResourceType implements providerops.ImportedManagedResource.
+func (i importedManagedResource) ResourceType() string {
+	return i.proto.TypeName
+}
+
+// State implements providerops.ImportedManagedResource.
+func (i importedManagedResource) State() providerschema.DynamicValueOut {
+	if i.proto.State == nil {
+		return nil
+	}
+	return dynamicValue{proto: i.proto.State}
+}
+
+// ProviderInternal implements providerops.ImportedManagedResource.
+func (i importedManagedResource) ProviderInternal() []byte {
+	return i.proto.Private
 }

--- a/tofuprovider/internal/tf6/provider_schema.go
+++ b/tofuprovider/internal/tf6/provider_schema.go
@@ -117,6 +117,14 @@ func (s schema) SchemaVersion() int64 {
 	return s.proto.Version
 }
 
+// DocDescription implements providerschema.Schema.
+func (s schema) DocDescription() (string, providerschema.DocStringFormat) {
+	if s.proto.Block == nil {
+		return "", providerschema.DocStringPlain
+	}
+	return s.proto.Block.Description, docStringFormat(s.proto.Block.DescriptionKind)
+}
+
 type attribute struct {
 	proto *tfplugin6.Schema_Attribute
 	common.SealedImpl

--- a/tofuprovider/providerschema/schema.go
+++ b/tofuprovider/providerschema/schema.go
@@ -28,6 +28,11 @@ type Schema interface {
 	// objects the result of this method is unspecified and meaningless.
 	SchemaVersion() int64
 
+	// DocDescription returns the provider's human-readable description
+	// of the schema block. The second result describes the intended format for the
+	// the description string.
+	DocDescription() (string, DocStringFormat)
+
 	// Schema is a kind of [BlockType], which is a configuration-oriented
 	// description of an object type in the OpenTofu language.
 	BlockType


### PR DESCRIPTION
This PR completes the implementation of core managed resource lifecycle operations for both TF5 (Protocol version 5) and TF6 (Protocol version 6) providers, bringing feature parity between both protocol versions.

### Summary

These changes implement the fundamental CRUD operations required for managed resources to function properly in both TF5 and TF6 providers. Prior to this PR, these operations were either unimplemented or incomplete, limiting the
library's ability to manage OpenTofu resources through the provider protocol.

### What's included

#### TF5 Managed Resource Operations
Implemented four critical managed resource operations:

- **`ApplyManagedResourceChange`**: Applies planned resource changes with full state management
  - Handles prior state, planned state, and configuration serialization to msgpack
  - Properly manages provider metadata and private state
  - Returns new state with diagnostics

- **`PlanManagedResourceChange`**: Plans resource modifications before application
  - Validates and converts prior state and proposed new state
  - Supports provider metadata and client capabilities
  - Returns planned state with private provider data

- **`ReadManagedResource`**: Reads current resource state
  - Retrieves and deserializes current resource state
  - Handles provider metadata and private state
  - Returns refreshed state with diagnostics

- **`ImportManagedResourceState`**: Imports existing resources into OpenTofu state
  - Enables importing resources by ID
  - Returns iterator over imported resource states
  - Supports multiple resource imports in a single operation

#### TF6 Managed Resource Operations
Implemented the same four operations for TF6 protocol with identical functionality but adapted to the TF6 protocol buffers specification.

#### Schema Documentation Support
Extended schema introspection capabilities:

- Added `DocDescription()` method to `providerschema.Schema` interface
- Returns human-readable descriptions and format type (`DocStringFormat`)
- Implemented in both TF5 and TF6 provider schema handlers
- Enables clients to retrieve documentation for provider schemas programmatically