### PR TITLE
tofuprovider: Drop GRPCPluginProvider.ProtocolMajorVersion

### DIFF
--- a/tofuprovider/internal/tf5/provider.go
+++ b/tofuprovider/internal/tf5/provider.go
@@ -32,10 +32,6 @@ func NewProvider(ctx context.Context, plugin *rpcplugin.Plugin, clientProxy any)
 	}, nil
 }
 
-func (p *Provider) ProtocolMajorVersion() int {
-	return 5
-}
-
 func (p *Provider) ClientProxy() any {
 	return p.client
 }

--- a/tofuprovider/internal/tf5/provider_test.go
+++ b/tofuprovider/internal/tf5/provider_test.go
@@ -20,9 +20,6 @@ func TestProviderBasics(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if got, want := provider.ProtocolMajorVersion(), 5; got != want {
-		t.Errorf("wrong ProtocolMajorVersion\ngot:  %d\nwant: %d", got, want)
-	}
 	if got, want := provider.ClientProxy(), client; got != want {
 		t.Error("ClientProxy did not return the originally-provided client")
 	}

--- a/tofuprovider/internal/tf6/provider.go
+++ b/tofuprovider/internal/tf6/provider.go
@@ -32,10 +32,6 @@ func NewProvider(ctx context.Context, plugin *rpcplugin.Plugin, clientProxy any)
 	}, nil
 }
 
-func (p *Provider) ProtocolMajorVersion() int {
-	return 6
-}
-
 func (p *Provider) ClientProxy() any {
 	return p.client
 }

--- a/tofuprovider/internal/tf6/provider_test.go
+++ b/tofuprovider/internal/tf6/provider_test.go
@@ -20,9 +20,6 @@ func TestProviderBasics(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if got, want := provider.ProtocolMajorVersion(), 6; got != want {
-		t.Errorf("wrong ProtocolMajorVersion\ngot:  %d\nwant: %d", got, want)
-	}
 	if got, want := provider.ClientProxy(), client; got != want {
 		t.Error("ClientProxy did not return the originally-provided client")
 	}

--- a/tofuprovider/provider_grpc.go
+++ b/tofuprovider/provider_grpc.go
@@ -32,27 +32,18 @@ type GRPCPluginProvider interface {
 	// inside this library rather than remotely in the plugin.
 	Provider
 
-	// ProtocolMajorVersion returns the major version number of the wire
-	// protocol that was negotiated during startup.
-	//
-	// In most cases the [Provider] abstraction should avoid callers needing
-	// to vary their behavior by major version. This is exposed primarily
-	// to allow callers to include it as diagnostic information in logs/etc
-	ProtocolMajorVersion() int
-
 	// ClientProxy returns the underlying gRPC client proxy object that this
 	// provider is using to make the lower-level protocol requests.
 	//
 	// The result implements a different interface depending on which major
-	// protocol version was negotiated, as returned by
-	// [GRPCPluginProvider.ProtocolMajorVersion]:
+	// protocol version was negotiated:
 	// - Version 6 client proxy implements [tfplugin6.ProviderClient]
 	// - Version 5 client proxy implements [tfplugin5.ProviderClient]
 	//
 	// The set of supported versions could change in future, so callers using
 	// this lower-level API should robustly handle recieving a client proxy
-	// that implements neither of these interfaces. If the goal is to use
-	// protocol features that are not part of this module's abstraction then
+	// that implements neither or both of these interfaces. If the goal is to
+	// use protocol features that are not part of this module's abstraction then
 	// it may be better to use the tfplugin5/tfplugin6 APIs directly with
 	// the underlying rpcplugin or go-plugin libraries and skip this
 	// abstraction altogether.


### PR DESCRIPTION
That method works okay for just the two protocol versions we support today, but is not very extensible to possible new protocol versions that we might support in future since they might not follow a linear sequence of integers and might not always be mutually-exclusive with one another.

Instead, callers that wish to vary their behavior by protocol version should call ClientProxy and type-assert the returned value. That's a more forward-extensible API because library could then return implementations of other interfaces in future, including possibly returning objects that implement multiple interfaces at once if we eventually extend the protocol in a way where one of these base interfaces is combined with OpenTofu-specific extensions defined in a separate protobuf schema.