### PR TITLE
tf6: Tests for `CallFunction` operation

### DIFF
--- a/tofuprovider/internal/mockutil/cmp_matcher.go
+++ b/tofuprovider/internal/mockutil/cmp_matcher.go
@@ -2,6 +2,7 @@ package mockutil
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/vmihailenco/msgpack/v5"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/opentofu/provider-client/tofuprovider/grpc/tfplugin5"
 	"github.com/opentofu/provider-client/tofuprovider/grpc/tfplugin6"
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
 	"github.com/opentofu/provider-client/tofuprovider/providerschema"
 )
 
@@ -134,9 +136,66 @@ var CmpOptions = cmp.Options{
 		},
 		protocmp.Transform(),
 	),
-	cmp.Transformer("comparableDiagnostic", cmpTransformDiagnostic),
 	cmp.Transformer("comparableDiagnostics", cmpTransformDiagnostics),
-	cmp.Transformer("comparableFunctionError", cmpTransformFunctionError),
+	interfaceTypeTransformer[providerops.Diagnostic](
+		"comparableDiagnostic", func(v any) *ComparableDiagnostic {
+			return cmpTransformDiagnostic(v.(providerops.Diagnostic))
+		},
+	),
+	interfaceTypeTransformer[providerops.FunctionError](
+		"comparableFunctionError", func(v any) *ComparableFunctionError {
+			return cmpTransformFunctionError(v.(providerops.FunctionError))
+		},
+	),
+}
+
+// interfaceTypeTransformer is a helper for using [cmp.Transformer] with
+// interface types.
+//
+// Unfortunately this requires some additional machinery because of how
+// [reflect.ValueOf] calls implicitly convert interface-typed values to the
+// generic [any], losing any more specific interface type that the value
+// had. To work around that we use [cmp.FilterPath] to test whether a value
+// implements the interface, and then use a transform function whose argument
+// is [any] to make sure it can match any concrete type.
+//
+// The given transform function should immediately unconditionally type-assert
+// the given argument to type Interface, which is guaranteed to succeed due
+// to this helper's filtering logic.
+func interfaceTypeTransformer[Interface, Concrete any](name string, tr func(any) Concrete) cmp.Option {
+	ifaceType := reflect.TypeFor[Interface]()
+	concreteType := reflect.TypeFor[Concrete]()
+	return cmp.FilterPath(
+		func(p cmp.Path) bool {
+			step := p.Last()
+			gotType := step.Type()
+			if gotType == concreteType {
+				// Avoid recursively transforming the transformer's own result.
+				return false
+			}
+			if gotType.Implements(ifaceType) {
+				// Easy case: it's a concrete type that implements the interface.
+				return true
+			}
+			if gotType.Kind() == reflect.Interface {
+				// Unfortunately if the given value was of an interface type
+				// already then gotType will just be reflect.TypeFor[any](), in
+				// which case we need to check the values themselves.
+				v1, v2 := step.Values()
+				if !(v1.IsValid() && v2.IsValid()) {
+					return false
+				}
+				if v1.IsNil() || v2.IsNil() {
+					return false
+				}
+				// Since v1 and v2 are both representing interface values,
+				// "Elem" here means to take the concrete-typed value inside.
+				return v1.Elem().Type().Implements(ifaceType) && v2.Elem().Type().Implements(ifaceType)
+			}
+			return false
+		},
+		cmp.Transformer(name, tr),
+	)
 }
 
 func buildCmpOptions(opts ...cmp.Option) cmp.Options {

--- a/tofuprovider/internal/mockutil/cmp_matcher.go
+++ b/tofuprovider/internal/mockutil/cmp_matcher.go
@@ -136,6 +136,7 @@ var CmpOptions = cmp.Options{
 	),
 	cmp.Transformer("comparableDiagnostic", cmpTransformDiagnostic),
 	cmp.Transformer("comparableDiagnostics", cmpTransformDiagnostics),
+	cmp.Transformer("comparableFunctionError", cmpTransformFunctionError),
 }
 
 func buildCmpOptions(opts ...cmp.Option) cmp.Options {

--- a/tofuprovider/internal/mockutil/function_error_matcher.go
+++ b/tofuprovider/internal/mockutil/function_error_matcher.go
@@ -1,0 +1,49 @@
+package mockutil
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/internal/common"
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+)
+
+// ComparableFunctionError is an implementation of [providerops.FunctionError]
+// that is friendly to being compared using functions from [cmp].
+//
+// If you use [Eq] (or other similar [gomock.Matcher] implementations based on
+// [Comparer]) or compare using [Diff], then any implementations of
+// [providerops.FunctionError] are automatically converted to this type so that
+// errors are compared by their user-facing content rather than by the types
+// used to implement them.
+//
+// This type is exported as a convenient way to describe "expected error"
+// in a test, using composite literal syntax.
+type ComparableFunctionError struct {
+	Text_          string
+	ArgumentIndex_ *int
+
+	common.SealedImpl
+}
+
+var _ providerops.FunctionError = (*ComparableFunctionError)(nil)
+
+// Text implements [providerops.FunctionError].
+func (c *ComparableFunctionError) Text() string {
+	return c.Text_
+}
+
+// ArgumentIndex implements [providerops.FunctionError].
+func (c *ComparableFunctionError) ArgumentIndex() (int, bool) {
+	if c.ArgumentIndex_ == nil {
+		return 0, false
+	}
+	return *c.ArgumentIndex_, true
+}
+
+func cmpTransformFunctionError(diag providerops.FunctionError) *ComparableFunctionError {
+	ret := &ComparableFunctionError{
+		Text_: diag.Text(),
+	}
+	if argIdx, ok := diag.ArgumentIndex(); ok {
+		ret.ArgumentIndex_ = new(argIdx)
+	}
+	return ret
+}

--- a/tofuprovider/internal/tf5/function.go
+++ b/tofuprovider/internal/tf5/function.go
@@ -52,7 +52,7 @@ func prepareFunctionArgs(args []providerschema.DynamicValueIn) ([]*tfplugin5.Dyn
 
 type callFunctionResponse struct {
 	proto *tfplugin5.CallFunction_Response
-	common.Sealed
+	common.SealedImpl
 }
 
 // Error implements providerops.CallFunctionResponse.
@@ -73,6 +73,7 @@ func (c callFunctionResponse) Result() providerschema.DynamicValueOut {
 
 type functionError struct {
 	proto *tfplugin5.FunctionError
+	common.SealedImpl
 }
 
 // ArgumentIndex implements providerops.FunctionError.

--- a/tofuprovider/internal/tf6/function.go
+++ b/tofuprovider/internal/tf6/function.go
@@ -52,7 +52,7 @@ func prepareFunctionArgs(args []providerschema.DynamicValueIn) ([]*tfplugin6.Dyn
 
 type callFunctionResponse struct {
 	proto *tfplugin6.CallFunction_Response
-	common.Sealed
+	common.SealedImpl
 }
 
 // Error implements providerops.CallFunctionResponse.
@@ -73,6 +73,7 @@ func (c callFunctionResponse) Result() providerschema.DynamicValueOut {
 
 type functionError struct {
 	proto *tfplugin6.FunctionError
+	common.SealedImpl
 }
 
 // ArgumentIndex implements providerops.FunctionError.

--- a/tofuprovider/internal/tf6/function_test.go
+++ b/tofuprovider/internal/tf6/function_test.go
@@ -1,0 +1,201 @@
+package tf6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/provider-client/tofuprovider/grpc/tfplugin6"
+	"github.com/opentofu/provider-client/tofuprovider/internal/mockutil"
+	"github.com/opentofu/provider-client/tofuprovider/internal/tf6"
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
+)
+
+func TestCallFunction(t *testing.T) {
+	testProviderCalls(t,
+		map[string]providerCallTest[*providerops.CallFunctionRequest, providerops.CallFunctionResponse]{
+			"no arguments": {
+				Mock: func(expect *MockProviderClientMockRecorder) {
+					expect.CallFunction(
+						mockutil.ContextWithValue("propagation_test", true),
+						mockutil.Eq(&tfplugin6.CallFunction_Request{
+							Name: "do_something",
+						}),
+					).Return(
+						&tfplugin6.CallFunction_Response{
+							Result: &tfplugin6.DynamicValue{
+								Msgpack: mockutil.MsgPack("done_something"),
+							},
+						}, nil,
+					)
+				},
+				Request: &providerops.CallFunctionRequest{
+					FunctionName: "do_something",
+				},
+				Check: func(t *testing.T, resp providerops.CallFunctionResponse) {
+					gotResult := resp.Result()
+					gotV, err := gotResult.AsCtyValue(cty.String)
+					if err != nil {
+						t.Fatalf("result has invalid syntax: %s", err)
+					}
+					if wantV := cty.StringVal("done_something"); !wantV.RawEquals(gotV) {
+						t.Errorf("wrong result\ngot:  %#v\nwant: %#v", gotV, wantV)
+					}
+					if gotErr := resp.Error(); gotErr != nil {
+						t.Errorf("unexpected error: %#v", gotErr)
+					}
+				},
+			},
+			"one argument": {
+				Mock: func(expect *MockProviderClientMockRecorder) {
+					expect.CallFunction(
+						mockutil.AnyContext(),
+						mockutil.Eq(&tfplugin6.CallFunction_Request{
+							Name: "do_something",
+							Arguments: []*tfplugin6.DynamicValue{
+								{Msgpack: mockutil.MsgPack("hello")},
+							},
+						}),
+					).Return(
+						&tfplugin6.CallFunction_Response{
+							Result: &tfplugin6.DynamicValue{
+								Msgpack: mockutil.MsgPack("done_something"),
+							},
+						}, nil,
+					)
+				},
+				Request: &providerops.CallFunctionRequest{
+					FunctionName: "do_something",
+					Arguments: []providerschema.DynamicValueIn{
+						providerschema.NewDynamicValue(cty.StringVal("hello"), cty.String),
+					},
+				},
+				Check: func(t *testing.T, resp providerops.CallFunctionResponse) {
+					gotResult := resp.Result()
+					gotV, err := gotResult.AsCtyValue(cty.String)
+					if err != nil {
+						t.Fatalf("result has invalid syntax: %s", err)
+					}
+					if wantV := cty.StringVal("done_something"); !wantV.RawEquals(gotV) {
+						t.Errorf("wrong result\ngot:  %#v\nwant: %#v", gotV, wantV)
+					}
+					if gotErr := resp.Error(); gotErr != nil {
+						t.Errorf("unexpected error: %#v", gotErr)
+					}
+				},
+			},
+			"two arguments": {
+				Mock: func(expect *MockProviderClientMockRecorder) {
+					expect.CallFunction(
+						mockutil.AnyContext(),
+						mockutil.Eq(&tfplugin6.CallFunction_Request{
+							Name: "do_something",
+							Arguments: []*tfplugin6.DynamicValue{
+								{Msgpack: mockutil.MsgPack("hello")},
+								{Msgpack: mockutil.MsgPack("world")},
+							},
+						}),
+					).Return(
+						&tfplugin6.CallFunction_Response{
+							Result: &tfplugin6.DynamicValue{
+								Msgpack: mockutil.MsgPack("done_something"),
+							},
+						}, nil,
+					)
+				},
+				Request: &providerops.CallFunctionRequest{
+					FunctionName: "do_something",
+					Arguments: []providerschema.DynamicValueIn{
+						providerschema.NewDynamicValue(cty.StringVal("hello"), cty.String),
+						providerschema.NewDynamicValue(cty.StringVal("world"), cty.String),
+					},
+				},
+				Check: func(t *testing.T, resp providerops.CallFunctionResponse) {
+					gotResult := resp.Result()
+					gotV, err := gotResult.AsCtyValue(cty.String)
+					if err != nil {
+						t.Fatalf("result has invalid syntax: %s", err)
+					}
+					if wantV := cty.StringVal("done_something"); !wantV.RawEquals(gotV) {
+						t.Errorf("wrong result\ngot:  %#v\nwant: %#v", gotV, wantV)
+					}
+					if gotErr := resp.Error(); gotErr != nil {
+						t.Errorf("unexpected error: %#v", gotErr)
+					}
+				},
+			},
+			"failed call with general error": {
+				Mock: func(expect *MockProviderClientMockRecorder) {
+					expect.CallFunction(
+						mockutil.AnyContext(),
+						mockutil.Eq(&tfplugin6.CallFunction_Request{
+							Name: "do_something",
+						}),
+					).Return(
+						&tfplugin6.CallFunction_Response{
+							Error: &tfplugin6.FunctionError{
+								Text: "failed to do something",
+							},
+						}, nil,
+					)
+				},
+				Request: &providerops.CallFunctionRequest{
+					FunctionName: "do_something",
+				},
+				Check: func(t *testing.T, resp providerops.CallFunctionResponse) {
+					gotErr := resp.Error()
+					wantErr := &mockutil.ComparableFunctionError{
+						Text_: "failed to do something",
+					}
+					if diff := mockutil.Diff(wantErr, gotErr); diff != "" {
+						t.Error("wrong error\n" + diff)
+					}
+				},
+			},
+			"failed call with argument-specific error": {
+				Mock: func(expect *MockProviderClientMockRecorder) {
+					expect.CallFunction(
+						mockutil.AnyContext(),
+						mockutil.Eq(&tfplugin6.CallFunction_Request{
+							Name: "do_something",
+							Arguments: []*tfplugin6.DynamicValue{
+								{Msgpack: mockutil.MsgPack("hey dude")},
+							},
+						}),
+					).Return(
+						&tfplugin6.CallFunction_Response{
+							Error: &tfplugin6.FunctionError{
+								Text:             "insufficiently polite greeting",
+								FunctionArgument: new(int64(0)),
+							},
+						}, nil,
+					)
+				},
+				Request: &providerops.CallFunctionRequest{
+					FunctionName: "do_something",
+					Arguments: []providerschema.DynamicValueIn{
+						providerschema.NewDynamicValue(cty.StringVal("hey dude"), cty.String),
+					},
+				},
+				Check: func(t *testing.T, resp providerops.CallFunctionResponse) {
+					gotErr := resp.Error()
+					wantErr := &mockutil.ComparableFunctionError{
+						Text_:          "insufficiently polite greeting",
+						ArgumentIndex_: new(0),
+					}
+					if diff := mockutil.Diff(wantErr, gotErr); diff != "" {
+						t.Error("wrong error\n" + diff)
+					}
+				},
+			},
+		},
+		func(t *testing.T, provider *tf6.Provider, req *providerops.CallFunctionRequest) (providerops.CallFunctionResponse, error) {
+			// So we can test trace span propagation, some of the tests
+			// use mocks that require a context with this key/value pair:
+			ctx := context.WithValue(t.Context(), "propagation_test", true)
+			return provider.CallFunction(ctx, req)
+		},
+	)
+}

--- a/tofuprovider/providerops/diagnostics.go
+++ b/tofuprovider/providerops/diagnostics.go
@@ -61,4 +61,6 @@ type FunctionError interface {
 	// for the problem along with true, or a meaningless value along with
 	// false if this error is not specific to an individual argument.
 	ArgumentIndex() (int, bool)
+
+	common.Sealed
 }


### PR DESCRIPTION
This uses the same test driver added in https://github.com/opentofu/provider-client/pull/5 to test the `CallFunction` operation.

We don't yet have all of the same helpers in `tf5` since https://github.com/opentofu/provider-client/pull/8 is still open at the time of writing, so this doesn't cover `tf5` yet. I'll add the equivalent `tf5` tests in a later PR, but I'm expecting that once this and https://github.com/opentofu/provider-client/pull/8 are in it'll generally be possible to add both the `tf5` and `tf6` tests for other features in a single PR each.

---

While testing the `ComparableFunctionError` type I added here I noticed that the transformer previously added for `ComparableDiagnostic` had only been working because I'd used it in a nested context where `cmp` can "see" the concrete type. Unfortunately the signature of `cmp.Diff` and `cmp.Equal` takes the two values to compare as `any` and so the top-level values can never directly match a transformer for a more specific interface type, so I had to add a rather awkward helper function that knows how to check the dynamic types of the values instead of just the static type. This now makes transformers work for both `Diagnostic` and `FunctionError`.

I also noticed while working on this that the "sealed" pattern was not being used correctly for the function-related interfaces, so I've also fixed that here.
