### PR TITLE
providerdefs: Default implementations of our interfaces

### DIFF
--- a/tofuprovider/internal/common/errors.go
+++ b/tofuprovider/internal/common/errors.go
@@ -1,0 +1,18 @@
+package common
+
+// UnimplementedError is one of the [error] types that we recognize as
+// representing "not implemented" in providerops.IsUnimplementedErr, though
+// we use it mainly for the default implementations in package providerdefs
+// since other provider implementations can return error types specific to
+// the protocol used for communication with the provider, like gRPC's own
+// "Unimplemented" error code.
+//
+// [ErrUnimplemented] is the only value of this type.
+type UnimplementedError struct{}
+
+func (UnimplementedError) Error() string {
+	return "not implemented"
+}
+
+// ErrUnimplemented is the only value of type [UnimplementedError].
+var ErrUnimplemented UnimplementedError

--- a/tofuprovider/internal/common/sealed.go
+++ b/tofuprovider/internal/common/sealed.go
@@ -1,13 +1,18 @@
 package common
 
 // Sealed is an interface that we embed in various other interface types to
-// ensure that they can't be implemented by types outside of this module,
-// because we need to be able to grow those interfaces over time as the
+// ensure that they can't be directly implemented by types outside of this
+// module, because we need to be able to grow those interfaces over time as the
 // underlying protocols evolve.
 //
-// This module uses interfaces only for dynamic dispatch over a fixed
+// This module uses interfaces mainly for dynamic dispatch over a fixed
 // set of implementations covering different versions of the plugin protocol,
-// and not to support third-party implementations.
+// and not to support third-party implementations. If you need to write a
+// third-party implementation e.g. for mocking in a calling application, you
+// can embed the zero-size base types from
+// [github.com/opentofu/provider-client/tofuproviders/providerdefs] to ensure
+// that your subtypes will automatically get default implementations of any
+// new methods added in later versions of this library.
 type Sealed interface {
 	// This unexported method can be implemented only by types in this
 	// package. Embed [SealedImpl] into another struct type to make it
@@ -18,6 +23,13 @@ type Sealed interface {
 // SealedImpl is a zero-sized type that implements [Sealed], intended to
 // be embedded into other struct types to make them implement that interface
 // even though they can't directly implement the "sealed()" method.
+//
+// If you've found this while attempting to implement an interface from this
+// library in an external Go module: the supported way to achieve that is
+// to embed the appropriate base type from
+// [github.com/opentofu/provider-client/tofuproviders/providerdefs] into your
+// implementation type, which will then implement [Sealed] while also providing
+// default implementations for any methods added in later versions.
 type SealedImpl struct{}
 
 // sealed implements [Sealed].

--- a/tofuprovider/providerdefs/call_function.go
+++ b/tofuprovider/providerdefs/call_function.go
@@ -1,0 +1,43 @@
+package providerdefs
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
+)
+
+// CallFunctionResponse is a base implementation of
+// [providerops.CallFunctionResponse].
+//
+// External implementations should embed this for forward-compatibility with
+// future extensions to the interface, but must still provide their own
+// implementations of [providerops.CallFunctionResponse.Result] and
+// [providerops.CallFunctionResponse.Error]
+type CallFunctionResponse struct {
+	sealedImpl
+}
+
+// NOTE: Right now there aren't actually any other methods of
+// CallFunctionResponse to implement here, but external implementers are
+// expected to embed this type anyway so that we can potentially add new methods
+// to the interface in future and then write their default implementations here.
+// If you're here reading this comment because that's what you're about to do
+// then you can remove this comment at the same time!
+
+// ===================== EXAMPLE IMPLEMENTATIONS ==============================
+//
+// The remaining unexported types are here just to make sure that a third-party
+// implementation that already has these methods can be made to implement
+// the corresponding interfaces just by embedding our default types from above.
+//
+// If future additions to the interface types cause failures here then the
+// appropriate fix is to add default implementations of those methods to the
+// exported types, _not_ to add those methods to these unexported types.
+
+type callFunctionResponseExample struct{ CallFunctionResponse }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerops.CallFunctionResponse = callFunctionResponseExample{}
+
+func (callFunctionResponseExample) Error() providerops.FunctionError       { panic("unimplemented") }
+func (callFunctionResponseExample) Result() providerschema.DynamicValueOut { panic("unimplemented") }

--- a/tofuprovider/providerdefs/capabilities.go
+++ b/tofuprovider/providerdefs/capabilities.go
@@ -1,0 +1,44 @@
+package providerdefs
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+)
+
+// ServerCapabilities is a base implementation of
+// [providerops.ServerCapabilities] that is intended to be embedded in external
+// implementations of that interface.
+//
+// It implements all methods of the interface, and will be expanded to return
+// reasonable default values for any other methods added in future. Refer to
+// the documentation of each method to learn what the default results are, and
+// override in your subtype as needed.
+type ServerCapabilities struct {
+	sealedImpl
+}
+
+var _ providerops.ServerCapabilities = ServerCapabilities{}
+
+// CanMoveManagedResourceState implements [providerops.ServerCapabilities] by
+// returning false, because it only makes sense to return true here for
+// providers that have a useful implementation of migrating between resource
+// types.
+func (ServerCapabilities) CanMoveManagedResourceState() bool {
+	return false
+}
+
+// CanPlanDestroy implements [providerops.ServerCapabilities] by returning
+// true, because this capability was added to accommodate some legacy
+// assumptions made by older providers but newly-written providers should
+// always support destroy-planning.
+func (ServerCapabilities) CanPlanDestroy() bool {
+	return true
+}
+
+// GetProviderSchemaIsOptional implements [providerops.ServerCapabilities]
+// by returning true, because this capability was added only to support some
+// quirky misbehavior in one specific legacy provider and so newly-written
+// providers should avoid relying on it and should behave correctly even if
+// the caller never requests provider schema.
+func (ServerCapabilities) GetProviderSchemaIsOptional() bool {
+	return true
+}

--- a/tofuprovider/providerdefs/configure_provider.go
+++ b/tofuprovider/providerdefs/configure_provider.go
@@ -1,0 +1,19 @@
+package providerdefs
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+)
+
+// ConfigureProviderResponse is a base implementation of
+// [providerops.ConfigureProviderResponse].
+type ConfigureProviderResponse struct {
+	sealedImpl
+}
+
+var _ providerops.ConfigureProviderResponse = ConfigureProviderResponse{}
+
+// Diagnostics implements [providerops.ConfigureProviderResponse] by returning
+// no diagnostics at all.
+func (c ConfigureProviderResponse) Diagnostics() providerops.Diagnostics {
+	return emptyDiagnostics{}
+}

--- a/tofuprovider/providerdefs/diagnostics.go
+++ b/tofuprovider/providerdefs/diagnostics.go
@@ -1,0 +1,107 @@
+package providerdefs
+
+import (
+	"iter"
+
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+)
+
+// Diagnostics is a base implementation of [providerops.Diagnostics]
+// intended to be embedded into implementations outside of this module.
+//
+// Implementations embedding this type must still provide their own
+// implementations of [providerops.Diagnostics.HasErrors] and
+// [providerops.Diagnostics.All], but any new methods added to the interface
+// type in future will have default implementations added to this base
+// type to ensure forward-compatibility.
+type Diagnostics struct {
+	sealedImpl
+}
+
+// emptyDiagnostics is an implementation of [providerops.Diagnostics] that
+// we use as part of default implementations of methods elsewhere that return
+// diagnostics, causting them to default to returning no diagnostics at all.
+//
+// This is unexported to discourage external implementers from just using
+// this "empty" implementation instead of implementing one that actually works.
+type emptyDiagnostics struct {
+	Diagnostics
+}
+
+var _ providerops.Diagnostics = emptyDiagnostics{}
+
+// All implements [providerops.Diagnostics].
+func (e emptyDiagnostics) All() iter.Seq[providerops.Diagnostic] {
+	return func(func(providerops.Diagnostic) bool) {}
+}
+
+// HasErrors implements [providerops.Diagnostics].
+func (e emptyDiagnostics) HasErrors() bool {
+	return false
+}
+
+// Diagnostics is a base implementation of [providerops.Diagnostic]
+// intended to be embedded into implementations outside of this module.
+//
+// Implementations embedding this type must still provide their own
+// implementations of [providerops.Diagnostic.Severity],
+// [providerops.Diagnostic.Summary], and
+// [providerops.Diagnostic.Detail], but any new methods added to the interface
+// type in future will have default implementations added to this base
+// type to ensure forward-compatibility.
+type Diagnostic struct {
+	sealedImpl
+}
+
+// Diagnostics is a base implementation of [providerops.FunctionError]
+// intended to be embedded into implementations outside of this module.
+//
+// Implementations embedding this type must still provide their own
+// implementation of [providerops.FunctionError.Text], but other methods
+// of the interface have default implementations in this base type.
+type FunctionError struct {
+	sealedImpl
+}
+
+// ArgumentIndex implements [providerops.FunctionError.ArgumentIndex] by just
+// always reporting that the error is not related to any single argument.
+func (FunctionError) ArgumentIndex() (int, bool) {
+	return 0, false
+}
+
+// ===================== EXAMPLE IMPLEMENTATIONS ==============================
+//
+// The remaining unexported types are here just to make sure that a third-party
+// implementation that already has these methods can be made to implement
+// the corresponding interfaces just by embedding our default types from above.
+//
+// If future additions to the interface types cause failures here then the
+// appropriate fix is to add default implementations of those methods to the
+// exported types, _not_ to add those methods to these unexported types.
+
+type diagnosticsExample struct{ Diagnostics }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerops.Diagnostics = diagnosticsExample{}
+
+func (diagnosticsExample) All() iter.Seq[providerops.Diagnostic] { panic("unimplemented") }
+func (diagnosticsExample) HasErrors() bool                       { panic("unimplemented") }
+
+type diagnosticExample struct{ Diagnostic }
+
+// If future additions to [providerops.Diagnostic] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerops.Diagnostic = diagnosticExample{}
+
+func (diagnosticExample) Severity() providerops.DiagnosticSeverity { panic("unimplemented") }
+func (diagnosticExample) Summary() string                          { panic("unimplemented") }
+func (diagnosticExample) Detail() string                           { panic("unimplemented") }
+
+type functionErrorExample struct{ FunctionError }
+
+// If future additions to [providerops.Diagnostic] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerops.FunctionError = functionErrorExample{}
+
+func (functionErrorExample) Text() string { panic("unimplemented") }

--- a/tofuprovider/providerdefs/doc.go
+++ b/tofuprovider/providerdefs/doc.go
@@ -1,0 +1,29 @@
+// Package providerdefs contains zero-sized implementations for the various
+// interface types in this library that can be embedded into types outside
+// of this library to allow external implementations in a forward-compatible
+// way.
+//
+// These types are all either complete or partial implementations of the
+// interfaces that will grow to include implementations of any new methods
+// added in future which return whatever result is appropriate to represent
+// "not implemented" or "not available". For those that are documented as being
+// only partial implementations, an external type relying on these will still
+// need to provide the remaining mandatory methods itself, but any new
+// methods added later will have default implementations that are designed to
+// behave similarly to what would happen when using an older provider plugin
+// that didn't yet support the new feature.
+package providerdefs
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/internal/common"
+)
+
+// sealedImpl is an unexported alias of [common.SealedImpl] that is here just
+// because otherwise the embedded type in each of our default types tends to
+// show up as a code completion suggestion due to being exported as a field
+// named "SealedImpl", and that's confusing.
+//
+// This type is embedded only to get its implementation of the unexported
+// [common.Sealed.sealed], so there's no reason for outside callers to access
+// it.
+type sealedImpl = common.SealedImpl

--- a/tofuprovider/providerdefs/dynamic_value.go
+++ b/tofuprovider/providerdefs/dynamic_value.go
@@ -1,0 +1,25 @@
+package providerdefs
+
+import (
+	"errors"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
+)
+
+// DynamicValueOut is a base implementation of [providerschema.DynamicValueOut].
+type DynamicValueOut struct {
+	sealedImpl
+}
+
+var _ providerschema.DynamicValueOut = DynamicValueOut{}
+
+// AsCtyValue implements [providerschema.DynamicValueOut] by immediately
+// returning an error.
+//
+// External implementers that embed [DynamicValueOut] should override this
+// to do somthing useful.
+func (d DynamicValueOut) AsCtyValue(withType cty.Type) (cty.Value, error) {
+	return cty.NilVal, errors.New("no value available")
+}

--- a/tofuprovider/providerdefs/get_functions.go
+++ b/tofuprovider/providerdefs/get_functions.go
@@ -1,0 +1,28 @@
+package providerdefs
+
+import (
+	"iter"
+
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
+)
+
+// GetFunctionsResponse is a base implementation of
+// [providerops.GetFunctionsResponse].
+type GetFunctionsResponse struct {
+	sealedImpl
+}
+
+var _ providerops.GetFunctionsResponse = GetFunctionsResponse{}
+
+// Diagnostics implements [providerops.GetFunctionsResponse] by returning
+// no diagnostics at all.
+func (g GetFunctionsResponse) Diagnostics() providerops.Diagnostics {
+	return emptyDiagnostics{}
+}
+
+// FunctionSignatures implements [providerops.GetFunctionsResponse] by reporting
+// that no functions exist.
+func (g GetFunctionsResponse) FunctionSignatures() iter.Seq2[string, providerschema.FunctionSignature] {
+	return func(func(string, providerschema.FunctionSignature) bool) {}
+}

--- a/tofuprovider/providerdefs/get_provider_schema.go
+++ b/tofuprovider/providerdefs/get_provider_schema.go
@@ -1,0 +1,46 @@
+package providerdefs
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
+)
+
+// GetProviderSchemaResponse is a base implementation of
+// [providerops.GetProviderSchemaResponse].
+type GetProviderSchemaResponse struct {
+	sealedImpl
+}
+
+// ServerCapabilities implements [providerops.GetProviderSchemaResponse] by
+// just returning the zero value of [ServerCapabilities].
+//
+// Relying on this implementation implies a default set of capabilities that
+// reflects what providers were expected to support at the time when this
+// library was originally created, in May 2026. Review the documentation of
+// [ServerCapabilities] to learn what those defaults are and decide whether you
+// ought to override this.
+func (g GetProviderSchemaResponse) ServerCapabilities() providerops.ServerCapabilities {
+	return ServerCapabilities{}
+}
+
+// ===================== EXAMPLE IMPLEMENTATIONS ==============================
+//
+// The remaining unexported types are here just to make sure that a third-party
+// implementation that already has these methods can be made to implement
+// the corresponding interfaces just by embedding our default types from above.
+//
+// If future additions to the interface types cause failures here then the
+// appropriate fix is to add default implementations of those methods to the
+// exported types, _not_ to add those methods to these unexported types.
+
+type getProviderSchemaResponseExample struct{ GetProviderSchemaResponse }
+
+// If future additions to [providerops.GetProviderSchemaResponse] cause a
+// compile-time error here, refer to the comment labeled
+// "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerops.GetProviderSchemaResponse = getProviderSchemaResponseExample{}
+
+func (getProviderSchemaResponseExample) Diagnostics() providerops.Diagnostics { panic("unimplemented") }
+func (getProviderSchemaResponseExample) ProviderSchema() providerschema.ProviderSchema {
+	panic("unimplemented")
+}

--- a/tofuprovider/providerdefs/provider.go
+++ b/tofuprovider/providerdefs/provider.go
@@ -1,0 +1,150 @@
+package providerdefs
+
+import (
+	"context"
+
+	"github.com/opentofu/provider-client/tofuprovider"
+	"github.com/opentofu/provider-client/tofuprovider/internal/common"
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+)
+
+// Provider is a base implementation of [tofuprovider.Provider] where most
+// methods immediately fail with an error that passes
+// [providerops.IsUnimplementedErr].
+//
+// Embed this into any external implementation of the interface so that your
+// type will automatically have default implementations of any new methods
+// added in later versions of this library.
+type Provider struct {
+	sealedImpl
+}
+
+var _ tofuprovider.Provider = Provider{}
+
+// ApplyManagedResourceChange implements [tofuprovider.Provider].
+func (Provider) ApplyManagedResourceChange(ctx context.Context, req *providerops.ApplyManagedResourceChangeRequest) (providerops.ApplyManagedResourceChangeResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// CallFunction implements [tofuprovider.Provider].
+func (Provider) CallFunction(ctx context.Context, req *providerops.CallFunctionRequest) (providerops.CallFunctionResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// CloseEphemeralResource implements [tofuprovider.Provider].
+func (Provider) CloseEphemeralResource(ctx context.Context, req *providerops.CloseEphemeralResourceRequest) (providerops.CloseEphemeralResourceResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ConfigureProvider implements [tofuprovider.Provider].
+func (Provider) ConfigureProvider(ctx context.Context, req *providerops.ConfigureProviderRequest) (providerops.ConfigureProviderResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// GetFunctions implements [tofuprovider.Provider].
+func (Provider) GetFunctions(ctx context.Context, req *providerops.GetFunctionsRequest) (providerops.GetFunctionsResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// GetProviderSchema implements [tofuprovider.Provider].
+func (Provider) GetProviderSchema(ctx context.Context, req *providerops.GetProviderSchemaRequest) (providerops.GetProviderSchemaResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// GracefulStop implements [tofuprovider.Provider] by doing absolutely nothing.
+func (Provider) GracefulStop(ctx context.Context) error {
+	// Doing nothing at all is a valid implementation of GracefulStop, so
+	// we'll do that as the default behavior.
+	return nil
+}
+
+// ImportManagedResourceState implements [tofuprovider.Provider].
+func (Provider) ImportManagedResourceState(ctx context.Context, req *providerops.ImportManagedResourceStateRequest) (providerops.ImportManagedResourceStateResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// MoveManagedResourceState implements [tofuprovider.Provider].
+func (Provider) MoveManagedResourceState(ctx context.Context, req *providerops.MoveManagedResourceStateRequest) (providerops.MoveManagedResourceStateResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// OpenEphemeralResource implements [tofuprovider.Provider].
+func (Provider) OpenEphemeralResource(ctx context.Context, req *providerops.OpenEphemeralResourceRequest) (providerops.OpenEphemeralResourceResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// PlanManagedResourceChange implements [tofuprovider.Provider].
+func (Provider) PlanManagedResourceChange(ctx context.Context, req *providerops.PlanManagedResourceChangeRequest) (providerops.PlanManagedResourceChangeResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ReadDataResource implements [tofuprovider.Provider].
+func (Provider) ReadDataResource(ctx context.Context, req *providerops.ReadDataResourceRequest) (providerops.ReadDataResourceResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ReadManagedResource implements [tofuprovider.Provider].
+func (Provider) ReadManagedResource(ctx context.Context, req *providerops.ReadManagedResourceRequest) (providerops.ReadManagedResourceResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// RenewEphemeralResource implements [tofuprovider.Provider].
+func (Provider) RenewEphemeralResource(ctx context.Context, req *providerops.RenewEphemeralResourceRequest) (providerops.RenewEphemeralResourceResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// UpgradeManagedResourceState implements [tofuprovider.Provider].
+func (Provider) UpgradeManagedResourceState(ctx context.Context, req *providerops.UpgradeManagedResourceStateRequest) (providerops.UpgradeManagedResourceStateResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ValidateDataResourceConfig implements [tofuprovider.Provider].
+func (Provider) ValidateDataResourceConfig(ctx context.Context, req *providerops.ValidateDataResourceConfigRequest) (providerops.ValidateDataResourceConfigResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ValidateEphemeralResourceConfig implements [tofuprovider.Provider].
+func (Provider) ValidateEphemeralResourceConfig(ctx context.Context, req *providerops.ValidateEphemeralResourceConfigRequest) (providerops.ValidateEphemeralResourceConfigResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ValidateManagedResourceConfig implements [tofuprovider.Provider].
+func (Provider) ValidateManagedResourceConfig(ctx context.Context, req *providerops.ValidateManagedResourceConfigRequest) (providerops.ValidateManagedResourceConfigResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// ValidateProviderConfig implements [tofuprovider.Provider].
+func (Provider) ValidateProviderConfig(ctx context.Context, req *providerops.ValidateProviderConfigRequest) (providerops.ValidateProviderConfigResponse, error) {
+	return nil, common.ErrUnimplemented
+}
+
+// GRPCPluginProvider is a base implementation of
+// [tofuprovider.GRPCPluginProvider] intended to be embedded in external
+// implementations of that interface, providing default implementations of
+// all of the required methods.
+//
+// This type embeds [Provider], inheriting its implementation of
+// [tofuprovider.Provider]. Use this base type only if your external
+// implementation for some reason needs to act like a gRPC provider in
+// particular, such as if you're mocking to test some code that manages
+// gRPC-based providers. If you're implementing some other kind of provider then
+// you should just embed [Provider] to implement the base interface, rather than
+// including is type's useless implementations of
+// [tofuprovider.GRPCPluginProvider].
+type GRPCPluginProvider struct {
+	Provider
+}
+
+var _ tofuprovider.GRPCPluginProvider = GRPCPluginProvider{}
+
+// ClientProxy implements [tofuprovider.GRPCPluginProvider] by returning a
+// value that is not assertable to any known gRPC client proxy interface.
+func (GRPCPluginProvider) ClientProxy() any {
+	return struct{}{}
+}
+
+// Close implements [tofuprovider.GRPCPluginProvider] by doing absolutely
+// nothing.
+func (GRPCPluginProvider) Close() error {
+	return nil
+}

--- a/tofuprovider/providerdefs/schema.go
+++ b/tofuprovider/providerdefs/schema.go
@@ -1,0 +1,275 @@
+package providerdefs
+
+import (
+	"iter"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/provider-client/tofuprovider/providerschema"
+)
+
+// Schema is a base implementation of [providerschema.Schema] whose default
+// methods describe a completely empty schema of version zero.
+type Schema struct {
+	BlockType
+}
+
+var _ providerschema.Schema = Schema{}
+
+// DocDescription implements [providerschema.Schema].
+func (Schema) DocDescription() (string, providerschema.DocStringFormat) {
+	return "", providerschema.DocStringPlain
+}
+
+// SchemaVersion implements [providerschema.Schema].
+func (Schema) SchemaVersion() int64 {
+	return 0
+}
+
+// Attribute is a base implementation of [providerschema.Attribute].
+//
+// If you embed this in your own implementation of the interface, you must still
+// implement [providerschema.Attribute.Usage] and exactly either
+// [providerschema.Attribute.Type] or [providerschema.Attribute.NestedType]
+// (but not both) to get a correctly-functioning implementation of the
+// interface.
+type Attribute struct {
+	sealedImpl
+}
+
+// NestedType implements [providerschema.Attribute] by returning nil.
+//
+// Note that nil is only a valid result if the "Type" method returns a valid,
+// non-nil type constraint, so downstream implementers MUST implement either
+// NestedType.
+func (Attribute) NestedType() providerschema.ObjectType {
+	return nil
+}
+
+// Type implements [providerschema.Attribute] by returning nil.
+//
+// Note that nil is only a valid result if the "NestedType" method returns a
+// valid, non-nil object type, so downstream implementers MUST implement either
+// Type or NestedType.
+func (Attribute) Type() providerschema.TypeConstraint {
+	return nil
+}
+
+// DocDescription implements [providerschema.Attribute].
+func (Attribute) DocDescription() (string, providerschema.DocStringFormat) {
+	return "", providerschema.DocStringPlain
+}
+
+// IsDeprecated implements [providerschema.Attribute].
+func (Attribute) IsDeprecated() bool {
+	return false
+}
+
+// IsSensitive implements [providerschema.Attribute].
+func (Attribute) IsSensitive() bool {
+	return false
+}
+
+// IsWriteOnly implements [providerschema.Attribute].
+func (Attribute) IsWriteOnly() bool {
+	return false
+}
+
+// BlockType is a base implementation of [providerschema.BlockType].
+type BlockType struct {
+	sealedImpl
+}
+
+var _ providerschema.BlockType = BlockType{}
+
+// Attributes implements [providerschema.BlockType] by reporting no attributes
+// at all.
+func (b BlockType) Attributes() iter.Seq2[string, providerschema.Attribute] {
+	return func(func(string, providerschema.Attribute) bool) {}
+}
+
+// NestedBlockTypes implements [providerschema.BlockType] by reporting no
+// nested block types at all.
+func (b BlockType) NestedBlockTypes() iter.Seq2[string, providerschema.NestedBlockType] {
+	return func(func(string, providerschema.NestedBlockType) bool) {}
+}
+
+// NestedBlockType is a base implementation of [providerschema.NestedBlockType].
+//
+// Implementers embedding this type must still provide their own implementation
+// of [providerschema.NestedBlockType.Nesting] to describe the nested block
+// type's nesting mode.
+type NestedBlockType struct {
+	BlockType
+}
+
+// ItemLimits implements [providerschema.NestedBlockType] by reporting no
+// item limits at all.
+func (n NestedBlockType) ItemLimits() (int64, int64) {
+	return 0, 0
+}
+
+// ObjectType is a base implementation of [providerschema.ObjectType].
+//
+// Implementers embedding this type must still provide their own implementation
+// of [providerschema.ObjectType.Nesting] to describe the nesting mode.
+type ObjectType struct {
+	sealedImpl
+}
+
+// Attributes implements [providerschema.ObjectType] by reporting no attributes
+// at all.
+func (o ObjectType) Attributes() iter.Seq2[string, providerschema.Attribute] {
+	return func(func(string, providerschema.Attribute) bool) {}
+}
+
+// TypeConstraint is a base implementation of [providerschema.TypeConstraint].
+//
+// Implementers embedding this type must still provide their own implementation
+// of [providerschema.TypeConstraint.AsCtyType].
+type TypeConstraint struct {
+	sealedImpl
+}
+
+// NOTE: Right now there aren't actually any other methods of TypeConstraint
+// to implement here, but external implementers are expected to embed this
+// type anyway so that we can potentially add new methods to the interface
+// in future and then write their default implementations here. If you're here
+// reading this comment because that's what you're about to do then you can
+// remove this comment at the same time!
+
+// TypeConstraint is a base implementation of [providerschema.ProviderSchema].
+type ProviderSchema struct {
+	sealedImpl
+}
+
+var _ providerschema.ProviderSchema = ProviderSchema{}
+
+// DataResourceTypeSchemas implements [providerschema.ProviderSchema] by
+// reporting no resource types at all.
+func (p ProviderSchema) DataResourceTypeSchemas() iter.Seq2[string, providerschema.Schema] {
+	return func(func(string, providerschema.Schema) bool) {}
+}
+
+// EphemeralResourceTypeSchemas implements [providerschema.ProviderSchema] by
+// reporting no resource types at all.
+func (p ProviderSchema) EphemeralResourceTypeSchemas() iter.Seq2[string, providerschema.Schema] {
+	return func(func(string, providerschema.Schema) bool) {}
+}
+
+// FunctionSignatures implements [providerschema.ProviderSchema] by reporting
+// no callable functions at all.
+func (p ProviderSchema) FunctionSignatures() iter.Seq2[string, providerschema.FunctionSignature] {
+	return func(func(string, providerschema.FunctionSignature) bool) {}
+}
+
+// ManagedResourceTypeSchemas implements [providerschema.ProviderSchema] by
+// reporting no resource types at all.
+func (p ProviderSchema) ManagedResourceTypeSchemas() iter.Seq2[string, providerschema.Schema] {
+	return func(func(string, providerschema.Schema) bool) {}
+}
+
+// ProviderConfigSchema implements [providerschema.ProviderSchema] by reporting
+// an empty schema.
+func (p ProviderSchema) ProviderConfigSchema() providerschema.Schema {
+	return Schema{}
+}
+
+// ProviderMetaSchema implements [providerschema.ProviderSchema] by returning
+// nil to indicate that this provider doesn't support "provider meta" at all.
+//
+// (Most providers should not implement this, because "provider meta" is a niche
+// feature that only serves the very narrow case of a module being written by
+// the same author as the main provider it uses and using that provider as a
+// way to collect usage data for the module.)
+func (p ProviderSchema) ProviderMetaSchema() providerschema.Schema {
+	return nil
+}
+
+// FunctionSignature is a base implementation of [providerschema.FunctionSignature].
+//
+// External implementers must still provide their own implementation of
+// [providerschema.FunctionSignature.ResultType].
+type FunctionSignature struct {
+	sealedImpl
+}
+
+// DeprecationMessage implements [providerschema.FunctionSignature] by reporting
+// no deprecation at all.
+func (f FunctionSignature) DeprecationMessage() string {
+	return ""
+}
+
+// DocDescription implements [providerschema.FunctionSignature] by returning
+// no documentation.
+func (f FunctionSignature) DocDescription() (string, providerschema.DocStringFormat) {
+	return "", providerschema.DocStringPlain
+}
+
+// DocSummary implements [providerschema.FunctionSignature] by returning no
+// summary.
+func (f FunctionSignature) DocSummary() string {
+	return ""
+}
+
+// Parameters implements [providerschema.FunctionSignature] by reporting that
+// there aren't any parameters.
+func (f FunctionSignature) Parameters() iter.Seq[providerschema.FunctionParameter] {
+	return func(func(providerschema.FunctionParameter) bool) {}
+}
+
+// VariadicParameter implements [providerschema.FunctionSignature] by reporting
+// that there is no variadic parameter.
+func (f FunctionSignature) VariadicParameter() providerschema.FunctionParameter {
+	return nil
+}
+
+// ===================== EXAMPLE IMPLEMENTATIONS ==============================
+//
+// The remaining unexported types are here just to make sure that a third-party
+// implementation that already has these methods can be made to implement
+// the corresponding interfaces just by embedding our default types from above.
+//
+// If future additions to the interface types cause failures here then the
+// appropriate fix is to add default implementations of those methods to the
+// exported types, _not_ to add those methods to these unexported types.
+
+type attributeExample struct{ Attribute }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerschema.Attribute = attributeExample{}
+
+func (attributeExample) Usage() providerschema.AttributeUsage { panic("unimplemented") }
+
+type nestedBlockTypeExample struct{ NestedBlockType }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerschema.NestedBlockType = nestedBlockTypeExample{}
+
+func (nestedBlockTypeExample) Nesting() providerschema.NestingMode { panic("unimplemented") }
+
+type objectTypeExample struct{ ObjectType }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerschema.ObjectType = objectTypeExample{}
+
+func (objectTypeExample) Nesting() providerschema.NestingMode { panic("unimplemented") }
+
+type typeConstraintExample struct{ TypeConstraint }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerschema.TypeConstraint = typeConstraintExample{}
+
+func (typeConstraintExample) AsCtyType() (cty.Type, error) { panic("unimplemented") }
+
+type functionSignatureExample struct{ FunctionSignature }
+
+// If future additions to [providerops.Diagnostics] cause a compile-time error
+// here, refer to the comment labeled "EXAMPLE IMPLEMENTATIONS" above.
+var _ providerschema.FunctionSignature = functionSignatureExample{}
+
+func (functionSignatureExample) ResultType() providerschema.TypeConstraint { panic("unimplemented") }

--- a/tofuprovider/providerdefs/validate_provider_config.go
+++ b/tofuprovider/providerdefs/validate_provider_config.go
@@ -1,0 +1,19 @@
+package providerdefs
+
+import (
+	"github.com/opentofu/provider-client/tofuprovider/providerops"
+)
+
+// ValidateProviderConfigResponse is a base implementation of
+// [providerops.ValidateProviderConfigResponse].
+type ValidateProviderConfigResponse struct {
+	sealedImpl
+}
+
+var _ providerops.ValidateProviderConfigResponse = ValidateProviderConfigResponse{}
+
+// Diagnostics implements [providerops.ValidateProviderConfigResponse] by
+// returning no diagnostics at all.
+func (v ValidateProviderConfigResponse) Diagnostics() providerops.Diagnostics {
+	return emptyDiagnostics{}
+}

--- a/tofuprovider/providerops/errors.go
+++ b/tofuprovider/providerops/errors.go
@@ -3,6 +3,8 @@ package providerops
 import (
 	grpcCodes "google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
+
+	"github.com/opentofu/provider-client/tofuprovider/internal/common"
 )
 
 // IsUnimplementedErr returns true if the given error represents "operation not
@@ -15,17 +17,13 @@ import (
 // [tofuprovider.Provider]. Errors obtained from other locations produce
 // unspecified results.
 func IsUnimplementedErr(err error) bool {
-	// We'll try to see if this is a gRPC "unimplemented" error. This
-	// function returns codes.Unimplemented only if the given error
-	// is based on a gRPC status with that code.
+	// The following matches all of the error values we expect that our own
+	// tofuprovider.Provider implementations could return.
 	switch {
 	case grpcStatus.Code(err) == grpcCodes.Unimplemented:
 		return true
-
-		// (if we have protocol implementations that are not gRPC-based in
-		// future then we should add additional cases to catch whatever
-		// they return to represent "unimplemented" here.)
-
+	case err == error(common.ErrUnimplemented):
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
This library uses interfaces primarily for their dynamic dispatch features and not to allow external implementations, and so all of the interfaces feature a method that cannot be named outside of this module to try to make it clear that external implementations cannot expect these interfaces to stay compatible in future versions: they are likely to grow as the underlying protocols change.

However, as we start to use this in OpenTofu itself we're likely to want to be able to at least write mock implementations of these interfaces for testing, and we might also choose to rework the
`terraform.io/builtin/terraform` provider as an implementation of `tofuprovider.Provider` and remove OpenTofu's own `providers.Interface` (but we've not decided that yet).

I did some research into how other libraries have dealt with this problem of allowing third-party implementations of an interface which is expected to grow in future versions, and found that the most prominent strategy is to require external implementers to embed a zero-sized type that will be extended to offer default implementations of any new methods added in later releases, which the external implementers would therefore automatically use after upgrading instead of being broken.

For example, this is the strategy used for the gRPC code generator for Go, where an implementation of the server interface (e.g. `tfplugin6.ProviderServer`) is expected to embed another type that implements all of the methods as returning "unimplemented" (e.g. `tfplugin6.UnimplementedProviderServer`).

The new `providerdefs` package added here follows a similar principle, and is intended to grow to offer a zero-sized type for every interface used for dynamic dispatch elsewhere in this module. In our case there are certain methods of interfaces that represent functionality that has just always been present in the provider protocol and so there's no reasonable "not implemented" result to return, and so some of our types are only partial implementations of the interface but the general promise is that if we extend the interfaces in future (after this library has seen its first stable release) then we'll design them such that there is a reasonable way to represent "unimplemented" and that the default implementation will use that as its result.

This pattern does unfortunately add a little friction to usage in that anyone writing external implementations will need to learn how to use this unusual approach, but it seems like the best available compromise with the current Go language design. This additional complexity only affects those who want to implement these interfaces in their own modules, so anyone who is just using this library to access the built-in `tf5` and `tf6` implementations can just ignore this completely. OpenTofu's own test code is probably going to be the main consumer of this new API.

This initial work only includes a subset of the interfaces, which should be sufficient to implement the `GetProviderSchema`, `GetFunctions`, `ValidateProviderConfig`, `ConfigureProvider`, and `CallFunction` methods of `Provider`. I intend to grow this further in future commits until it's fully comprehensive for implementing the entire `tofuprovider.Provider` API.
