### PR TITLE
feat: add identity data to list resources

### DIFF
--- a/examples/list-resources/main.go
+++ b/examples/list-resources/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 
 	"github.com/zclconf/go-cty/cty"
@@ -62,6 +63,31 @@ func main() {
 	resourceType, err := impliedType(resourceSchema)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	identityResp, err := provider.GetIdentitySchemas(ctx, &providerops.GetIdentitySchemasRequest{})
+	var identitySchema providerschema.IdentitySchema
+	switch {
+	case providerops.IsUnimplementedErr(err):
+		// Older providers don't implement the resource identity RPC.
+	case err != nil:
+		fmt.Fprintf(os.Stderr, "Identity schemas request failed: %s\n", err)
+		os.Exit(1)
+	default:
+		s, ok := maps.Collect(identityResp.IdentitySchemas())[resourceTypeName]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Error: provider has no %s identity schema\n", resourceTypeName)
+			os.Exit(1)
+		}
+		identitySchema = s
+	}
+
+	var identityType cty.Type
+	if identitySchema != nil {
+		identityType, err = identityImpliedType(identitySchema)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	providerConfigType, err := impliedType(resp.ProviderSchema().ProviderConfigSchema())
@@ -129,14 +155,37 @@ func main() {
 
 		fmt.Printf("- display name: %s\n", res.DisplayName())
 
+		if id := res.Identity(); id != nil && identitySchema != nil {
+			idVal, err := id.IdentityData().AsCtyValue(identityType)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("  identity:\n")
+			for k, v := range idVal.AsValueMap() {
+				fmt.Printf("    %s: %s\n", k, v.AsString())
+			}
+		}
+
 		if r := res.Resource(); r != nil {
 			resVal, err := res.Resource().AsCtyValue(resourceType)
 			if err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf(" %+v\n", resVal)
+			fmt.Printf("  attributes:\n  %+v\n", resVal)
 		}
 	}
+}
+
+func identityImpliedType(schema providerschema.IdentitySchema) (cty.Type, error) {
+	attrTypes := map[string]cty.Type{}
+	for name, attr := range schema.Attributes() {
+		ty, err := attr.Type().AsCtyType()
+		if err != nil {
+			return cty.NilType, fmt.Errorf("identity attribute %q: %w", name, err)
+		}
+		attrTypes[name] = ty
+	}
+	return cty.Object(attrTypes), nil
 }
 
 func impliedType(block providerschema.BlockType) (cty.Type, error) {

--- a/tofuprovider/internal/tf5/list.go
+++ b/tofuprovider/internal/tf5/list.go
@@ -53,7 +53,9 @@ func (r *listManagedResourcesResponse) ReadResult(_ context.Context) (providerop
 		displayName: res.GetDisplayName(),
 	}
 
-	// TODO Fetch identity data
+	if identity := res.GetIdentity(); identity != nil {
+		item.identity = resourceIdentityData{proto: identity}
+	}
 
 	if res := res.GetResourceObject(); res != nil {
 		item.resource = dynamicValue{proto: res}
@@ -70,6 +72,7 @@ func (r *listManagedResourcesResponse) Close(_ context.Context) error {
 type listManagedResourcesEvent struct {
 	displayName string
 	resource    providerschema.DynamicValueOut
+	identity    resourceIdentityData
 	diagnostics providerops.Diagnostics
 
 	common.SealedImpl
@@ -77,4 +80,5 @@ type listManagedResourcesEvent struct {
 
 func (i listManagedResourcesEvent) DisplayName() string                      { return i.displayName }
 func (i listManagedResourcesEvent) Resource() providerschema.DynamicValueOut { return i.resource }
+func (i listManagedResourcesEvent) Identity() providerschema.IdentityData    { return i.identity }
 func (i listManagedResourcesEvent) Diagnostics() providerops.Diagnostics     { return i.diagnostics }

--- a/tofuprovider/internal/tf5/list.go
+++ b/tofuprovider/internal/tf5/list.go
@@ -72,7 +72,7 @@ func (r *listManagedResourcesResponse) Close(_ context.Context) error {
 type listManagedResourcesEvent struct {
 	displayName string
 	resource    providerschema.DynamicValueOut
-	identity    resourceIdentityData
+	identity    providerschema.IdentityData
 	diagnostics providerops.Diagnostics
 
 	common.SealedImpl

--- a/tofuprovider/internal/tf5/list_test.go
+++ b/tofuprovider/internal/tf5/list_test.go
@@ -59,6 +59,9 @@ func TestListManagedResourcesImpl(t *testing.T) {
 							{
 								DisplayName:    "resource2",
 								ResourceObject: &tfplugin5.DynamicValue{Msgpack: mockutil.MsgPack(map[string]string{"id": "123"})},
+								Identity: &tfplugin5.ResourceIdentityData{
+									IdentityData: &tfplugin5.DynamicValue{Msgpack: mockutil.MsgPack(map[string]string{"id": "4321"})},
+								},
 							},
 						},
 					}, nil)
@@ -109,6 +112,13 @@ func TestListManagedResourcesImpl(t *testing.T) {
 					}
 					if got, expected := resourceObject.GetAttr("id").AsString(), "123"; got != expected {
 						t.Errorf("wrong resource object foo field: got %q, want %q", got, expected)
+					}
+					identity, err := resources[1].Identity().IdentityData().AsCtyValue(cty.Object(map[string]cty.Type{"id": cty.String}))
+					if err != nil {
+						t.Fatalf("identity data invalid: %s", err)
+					}
+					if got, expected := identity.GetAttr("id").AsString(), "4321"; got != expected {
+						t.Errorf("wrong identity id field: got %q, want %q", got, expected)
 					}
 				},
 			},

--- a/tofuprovider/internal/tf5/resource_identity.go
+++ b/tofuprovider/internal/tf5/resource_identity.go
@@ -133,3 +133,12 @@ func (u upgradeIdentityResponse) UpgradedIdentity() providerschema.DynamicValueO
 	}
 	return dynamicValue{proto: u.proto.UpgradedIdentity.IdentityData}
 }
+
+type resourceIdentityData struct {
+	proto *tfplugin5.ResourceIdentityData
+	common.SealedImpl
+}
+
+func (r resourceIdentityData) IdentityData() providerschema.DynamicValueOut {
+	return dynamicValue{proto: r.proto.GetIdentityData()}
+}

--- a/tofuprovider/internal/tf6/list.go
+++ b/tofuprovider/internal/tf6/list.go
@@ -60,7 +60,9 @@ func (r *listManagedResourcesResponse) ReadResult(_ context.Context) (providerop
 		displayName: res.GetDisplayName(),
 	}
 
-	// TODO Fetch identity data
+	if identity := res.GetIdentity(); identity != nil {
+		item.identity = resourceIdentityData{proto: identity}
+	}
 
 	if res := res.GetResourceObject(); res != nil {
 		item.resource = dynamicValue{proto: res}
@@ -80,6 +82,7 @@ func (r *listManagedResourcesResponse) Close(_ context.Context) error {
 type listManagedResourcesEvent struct {
 	displayName string
 	resource    providerschema.DynamicValueOut
+	identity    resourceIdentityData
 	diagnostics providerops.Diagnostics
 
 	common.SealedImpl
@@ -87,4 +90,5 @@ type listManagedResourcesEvent struct {
 
 func (i listManagedResourcesEvent) DisplayName() string                      { return i.displayName }
 func (i listManagedResourcesEvent) Resource() providerschema.DynamicValueOut { return i.resource }
+func (i listManagedResourcesEvent) Identity() providerschema.IdentityData    { return i.identity }
 func (i listManagedResourcesEvent) Diagnostics() providerops.Diagnostics     { return i.diagnostics }

--- a/tofuprovider/internal/tf6/list_test.go
+++ b/tofuprovider/internal/tf6/list_test.go
@@ -59,6 +59,9 @@ func TestListManagedResourcesImpl(t *testing.T) {
 							{
 								DisplayName:    "resource2",
 								ResourceObject: &tfplugin6.DynamicValue{Msgpack: mockutil.MsgPack(map[string]string{"id": "123"})},
+								Identity: &tfplugin6.ResourceIdentityData{
+									IdentityData: &tfplugin6.DynamicValue{Msgpack: mockutil.MsgPack(map[string]string{"id": "4321"})},
+								},
 							},
 						},
 					}, nil)
@@ -109,6 +112,13 @@ func TestListManagedResourcesImpl(t *testing.T) {
 					}
 					if got, expected := resourceObject.GetAttr("id").AsString(), "123"; got != expected {
 						t.Errorf("wrong resource object foo field: got %q, want %q", got, expected)
+					}
+					identity, err := resources[1].Identity().IdentityData().AsCtyValue(cty.Object(map[string]cty.Type{"id": cty.String}))
+					if err != nil {
+						t.Fatalf("identity data invalid: %s", err)
+					}
+					if got, expected := identity.GetAttr("id").AsString(), "4321"; got != expected {
+						t.Errorf("wrong identity id field: got %q, want %q", got, expected)
 					}
 				},
 			},

--- a/tofuprovider/internal/tf6/resource_identity.go
+++ b/tofuprovider/internal/tf6/resource_identity.go
@@ -133,3 +133,12 @@ func (u upgradeIdentityResponse) UpgradedIdentity() providerschema.DynamicValueO
 	}
 	return dynamicValue{proto: u.proto.UpgradedIdentity.IdentityData}
 }
+
+type resourceIdentityData struct {
+	proto *tfplugin6.ResourceIdentityData
+	common.SealedImpl
+}
+
+func (r resourceIdentityData) IdentityData() providerschema.DynamicValueOut {
+	return dynamicValue{proto: r.proto.GetIdentityData()}
+}

--- a/tofuprovider/providerops/list_resource.go
+++ b/tofuprovider/providerops/list_resource.go
@@ -23,6 +23,7 @@ type ListManagedResourcesRequest struct {
 type ListManagedResourcesEvent interface {
 	DisplayName() string
 	Resource() providerschema.DynamicValueOut
+	Identity() providerschema.IdentityData
 	Diagnostics() Diagnostics
 
 	common.Sealed

--- a/tofuprovider/providerschema/identity_schema.go
+++ b/tofuprovider/providerschema/identity_schema.go
@@ -2,11 +2,10 @@ package providerschema
 
 import (
 	"iter"
-
-	"github.com/opentofu/provider-client/tofuprovider/internal/common"
-
 	// For links in documentation comments:
 	_ "maps"
+
+	"github.com/opentofu/provider-client/tofuprovider/internal/common"
 )
 
 // IdentitySchema describes the structure of the data used to identify a
@@ -59,6 +58,15 @@ type IdentityAttribute interface {
 	// returned in the result of a provider call, which does not apply to
 	// the identity values a caller supplies during import.
 	ImportUsage() AttributeUsage
+
+	// This interface cannot be implemented outside of this module, because
+	// future versions might extend the interface to include new protocol
+	// features.
+	common.Sealed
+}
+
+type IdentityData interface {
+	IdentityData() DynamicValueOut
 
 	// This interface cannot be implemented outside of this module, because
 	// future versions might extend the interface to include new protocol

--- a/tofuprovider/providerschema/identity_schema.go
+++ b/tofuprovider/providerschema/identity_schema.go
@@ -66,6 +66,8 @@ type IdentityAttribute interface {
 }
 
 type IdentityData interface {
+	// IdentityData is the resource identity data of the resource instance.
+	// It should be decoded using [IdentitySchema] and [IdentityAttribute].
 	IdentityData() DynamicValueOut
 
 	// This interface cannot be implemented outside of this module, because


### PR DESCRIPTION
This adds identity data to the list resource call. It also update the example based on the work done in https://github.com/opentofu/provider-client/pull/11 to retreive identity schema and data.
So we're now able to unpack typed identity data for resources returned by the list resource call.